### PR TITLE
fix: use ui.hide with fallback for yazi compatibility

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -9,7 +9,7 @@ return {
                 timeout = 5,
             })
         else
-            permit = ya.hide()
+            permit = ui.hide and ui.hide() or ya.hide()
             local output, err_code = Command("lazygit"):stdin(Command.INHERIT):stdout(Command.INHERIT):stderr(Command.PIPED):spawn()
             if output and not err_code then
                 output, err_code = output:wait_with_output()


### PR DESCRIPTION
In the latest version of Yazi released today, it shows a deprecation warning when LazyGit is closed. 
- See [PR #2939 in Yazi repo](https://github.com/sxyazi/yazi/pull/2939) for details.

This fix replaces the deprecated `ya.hide()` with `ui.hide()` while maintaining backward compatibility with older yazi versions.